### PR TITLE
Feature/cu 85zrruq0d resolve dependency of hubdockercom

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: dumptrack
+  IMAGE_NAME: dumptruck
 
 jobs:
   build:
@@ -47,7 +47,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@v4
         with:
-          context: dumptrack/
+          context: dumptruck/
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,21 +3,51 @@ name: Automate dumptruck release
 on:
   release:
     types: [published]
-    
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: dumptrack
+
 jobs:
   build:
-    name: Push Docker image to Docker Hub
+    name: Push Docker image to Github Container Registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-# This action will log in against a Docker registry. 
-        - name: Login to DockerHub Registry
-          uses: docker/login-action@v2
-          with:
-            username: ${{ secrets.DOCKERHUB_USERNAME }}
-            password: ${{ secrets.DOCKERHUB_PASSWORD }}
-# This action will Build and Push the latest Docker image to Docker Hub.
-        - name: Build and push
-          uses: docker/build-push-action@v3
-          with:
-            push: true
-            tags: meshcloud/dumptruck:latest
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          context: dumptrack/
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    name: Push Docker image to Github Container Registry
+    name: Push Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
hey, changed the build process from docker to github. is that workaround https://github.com/docker/build-push-action/issues/461 still needed? I used the newest versions and that issue is closed with a fix. However, anyone should change the secrets, i can't do it?