### PR TITLE
feat: support custom labels for monitor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+1.3 Jul 23, 2025
+====================
+
+* Add support for generic custom labels in monitor configuration
+* Improve documentation for monitor configuration with usage examples
+
 1.2 Dec 20, 2018
 ====================
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,40 @@ We can also use Rclone to store our dumps somewhere. This will require an additi
 }
 ```
 
+### Monitor
+
+The `monitor` section configures a Prometheus Pushgateway for reporting backup metrics. This is optional but recommended for production deployments.
+
+```text
+{
+  "url": "https://ourpushgateway/",
+  "username": "push",
+  "password": "********",
+  "labels": {
+    "namespace": "production",
+    "environment": "prod",
+    "region": "us-east-1"
+  }
+}
+```
+
+The `labels` field is optional and allows you to add custom labels to the metrics. This is particularly useful when using a centralized Pushgateway that receives metrics from multiple environments or namespaces. Common use cases include:
+
+- **Kubernetes deployments**: Add a `namespace` label to identify which Kubernetes namespace the backup is running in
+- **Multi-environment setups**: Add `environment` labels like `dev`, `staging`, `prod`
+- **Multi-region deployments**: Add `region` labels to identify the geographic location
+- **Custom organizational labels**: Add any labels that help with your monitoring and alerting setup
+
+The following metrics are exported to the pushgateway:
+- `backup_time_seconds`: Unix timestamp of the last successful backup
+- `backup_status`: `1` for successful backups, `-1` for failed backups
+
+Both metrics include the following default labels:
+- `database`: The database name being backed up
+- `type`: The database type (mysql, postgres, mongo, etc.)
+
+Plus any custom labels you define in the `labels` configuration.
+
 ### Crontab
 
 The `crontab` determines when and how often backups should be performed. Backups can be performed with different intervals by adding entries for different config files, i.e.:

--- a/bin/dumptruck.py
+++ b/bin/dumptruck.py
@@ -178,22 +178,20 @@ def notify_success(source, username, password, url, labels=None):
     source = dict(source)
     source.setdefault("database", "")
 
-    # Build extra labels string from the labels dict
-    extra_labels = ""
-    if labels:
-        for key, value in labels.items():
-            extra_labels += f',{key}="{value}"'
+    default_labels = [f'database="{source["database"]}"', f'type="{source["dbtype"]}"']
+    all_labels = default_labels + [f'{key}="{value}"' for key, value in labels.items()] if labels else default_labels
+    labels_str = ",".join(all_labels)
 
     data = "\n".join(
         (
             "# TYPE backup_time_seconds gauge",
             "# HELP backup_time_seconds Last Unix time when this source was backed up.",
-            'backup_time_seconds{{database="{database}",type="{dbtype}"{extra_labels}}} {time}\n'
+            'backup_time_seconds{{{labels_str}}} {time}\n'
             "# TYPE backup_status gauge",
             "# HELP backup_status Indicates success/failure of the last backup attempt.",
-            'backup_status{{database="{database}",type="{dbtype}"{extra_labels}}} 1\n',
+            'backup_status{{{labels_str}}} 1\n',
         )
-    ).format(database=source["database"], dbtype=source["dbtype"], extra_labels=extra_labels, time=time.time())
+    ).format(labels_str=labels_str, time=time.time())
     notify(source, username, password, url, data)
 
 
@@ -201,19 +199,17 @@ def notify_failure(source, username, password, url, labels=None):
     source = dict(source)
     source.setdefault("database", "")
 
-    # Build extra labels string from the labels dict
-    extra_labels = ""
-    if labels:
-        for key, value in labels.items():
-            extra_labels += f',{key}="{value}"'
+    default_labels = [f'database="{source["database"]}"', f'type="{source["dbtype"]}"']
+    all_labels = default_labels + [f'{key}="{value}"' for key, value in labels.items()] if labels else default_labels
+    labels_str = ",".join(all_labels)
 
     data = "\n".join(
         (
             "# TYPE backup_status gauge",
             "# HELP backup_status Indicates success/failure of the last backup attempt.",
-            'backup_status{{database="{database}",type="{dbtype}"{extra_labels}}} -1\n',
+            'backup_status{{{labels_str}}} -1\n',
         )
-    ).format(database=source["database"], dbtype=source["dbtype"], extra_labels=extra_labels)
+    ).format(labels_str=labels_str)
     notify(source, username, password, url, data)
 
 

--- a/bin/dumptruck.py
+++ b/bin/dumptruck.py
@@ -174,33 +174,46 @@ def notify(source, username, password, url, data):
     print(resp.text)
 
 
-def notify_success(source, username, password, url):
+def notify_success(source, username, password, url, labels=None):
     source = dict(source)
     source.setdefault("database", "")
+
+    # Build extra labels string from the labels dict
+    extra_labels = ""
+    if labels:
+        for key, value in labels.items():
+            extra_labels += f',{key}="{value}"'
+
     data = "\n".join(
         (
             "# TYPE backup_time_seconds gauge",
             "# HELP backup_time_seconds Last Unix time when this source was backed up.",
-            'backup_time_seconds{{database="{database}",type="{dbtype}"}} {time}\n'
+            'backup_time_seconds{{database="{database}",type="{dbtype}"{extra_labels}}} {time}\n'
             "# TYPE backup_status gauge",
             "# HELP backup_status Indicates success/failure of the last backup attempt.",
-            'backup_status{{database="{database}",type="{dbtype}"}} 1\n',
+            'backup_status{{database="{database}",type="{dbtype}"{extra_labels}}} 1\n',
         )
-    ).format(database=source["database"], dbtype=source["dbtype"], time=time.time())
+    ).format(database=source["database"], dbtype=source["dbtype"], extra_labels=extra_labels, time=time.time())
     notify(source, username, password, url, data)
 
 
-def notify_failure(source, username, password, url):
+def notify_failure(source, username, password, url, labels=None):
     source = dict(source)
     source.setdefault("database", "")
+
+    # Build extra labels string from the labels dict
+    extra_labels = ""
+    if labels:
+        for key, value in labels.items():
+            extra_labels += f',{key}="{value}"'
 
     data = "\n".join(
         (
             "# TYPE backup_status gauge",
             "# HELP backup_status Indicates success/failure of the last backup attempt.",
-            'backup_status{{database="{database}",type="{dbtype}"}} -1\n',
+            'backup_status{{database="{database}",type="{dbtype}"{extra_labels}}} -1\n',
         )
-    ).format(database=source["database"], dbtype=source["dbtype"])
+    ).format(database=source["database"], dbtype=source["dbtype"], extra_labels=extra_labels)
     notify(source, username, password, url, data)
 
 

--- a/daily.json.sample
+++ b/daily.json.sample
@@ -49,6 +49,11 @@
   "monitor": {
     "url": "https://ourpushgateway/",
     "username": "push",
-    "password": "********"
+    "password": "********",
+    "labels": {
+      "namespace": "production",
+      "environment": "prod",
+      "region": "us-east-1"
+    }
   }
 }


### PR DESCRIPTION
This is useful to identify dumptruck source (e.g. when having a centralized pushgateway) to avoid duplicate metrics.